### PR TITLE
chore: Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-01-18
+
 ### Fixed
 
 - 타이포그래피 유틸리티 클래스가 빌드에 포함되지 않던 문제 수정
@@ -207,7 +209,8 @@
 - Storybook 설정
 - Vitest 테스트 설정
 
-[Unreleased]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/Team-NumberOne/daepiro-design-system/compare/v0.1.5...v0.1.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-numberone/daepiro-design-system",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "대피로 디자인 시스템 - React 컴포넌트 라이브러리",
   "private": false,
   "packageManager": "pnpm@10.25.0",


### PR DESCRIPTION
## 📝 Summary

vanilla-extract 완전 제거 및 타이포그래피 유틸리티 클래스 빌드 이슈 수정

## 🎯 Changes

### Fixed
- 타이포그래피 유틸리티 클래스 빌드 이슈 수정
  - `@utility` → `@layer utilities` 변경
  - `text-h6`, `text-body-1-b` 등 모든 타이포그래피 클래스가 사용처에서 정상 작동

### Removed  
- vanilla-extract 관련 의존성 완전 제거
  - `@vanilla-extract/css`
  - `@vanilla-extract/esbuild-plugin`
  - `@vanilla-extract/vite-plugin`
- 빌드 설정 파일 정리
  - `vitest.config.ts`
  - `vite.config.ts`
  - `tsup.config.ts`

## ✅ Checklist
- [x] 빌드 성공
- [x] 테스트 통과
- [x] 버전 업데이트 (0.2.2)
- [x] CHANGELOG 업데이트

## 📦 Version
0.2.1 → 0.2.2